### PR TITLE
Wrapper core

### DIFF
--- a/src/main/java/fr/inria/corese/command/utils/coreseCoreWrapper/GraphWrapper.java
+++ b/src/main/java/fr/inria/corese/command/utils/coreseCoreWrapper/GraphWrapper.java
@@ -1,0 +1,10 @@
+package fr.inria.corese.command.utils.coreseCoreWrapper;
+
+import fr.inria.corese.core.Graph;
+
+public class GraphWrapper {
+
+    public static Graph createGraph() {
+        return Graph.create();
+    }
+}

--- a/src/main/java/fr/inria/corese/command/utils/coreseCoreWrapper/GraphWrapper.java
+++ b/src/main/java/fr/inria/corese/command/utils/coreseCoreWrapper/GraphWrapper.java
@@ -2,12 +2,27 @@ package fr.inria.corese.command.utils.coreseCoreWrapper;
 
 import fr.inria.corese.core.Graph;
 
+/**
+ * A wrapper class for Corese Graph operations.
+ * This class provides static methods to create and manipulate Graph instances.
+ */
 public class GraphWrapper {
 
+    /**
+     * Creates a new empty Graph instance.
+     *
+     * @return a new Graph object
+     */
     public static Graph createGraph() {
         return Graph.create();
     }
 
+    /**
+     * Merges the contents of the resultGraphUrl into the given graph.
+     *
+     * @param graph the graph to merge into
+     * @param resultGraphUrl the graph whose contents are to be merged
+     */
     public static void mergeGraph(Graph graph, Graph resultGraphUrl) {
         graph.merge(resultGraphUrl);
     }    

--- a/src/main/java/fr/inria/corese/command/utils/coreseCoreWrapper/GraphWrapper.java
+++ b/src/main/java/fr/inria/corese/command/utils/coreseCoreWrapper/GraphWrapper.java
@@ -7,4 +7,8 @@ public class GraphWrapper {
     public static Graph createGraph() {
         return Graph.create();
     }
+
+    public static void mergeGraph(Graph graph, Graph resultGraphUrl) {
+        graph.merge(resultGraphUrl);
+    }    
 }

--- a/src/main/java/fr/inria/corese/command/utils/coreseCoreWrapper/RDFLoaderWrapper.java
+++ b/src/main/java/fr/inria/corese/command/utils/coreseCoreWrapper/RDFLoaderWrapper.java
@@ -1,0 +1,16 @@
+package fr.inria.corese.command.utils.coreseCoreWrapper;
+
+
+import fr.inria.corese.core.Graph;
+import fr.inria.corese.core.load.Load;
+
+/** A class to gather all dependencies to Corese-core in one place
+ * This one is for everything related to RDFLoading
+ */
+public class RDFLoaderWrapper {
+
+    public static Load graphLoader(Graph graph) {
+        return Load.create(graph);
+    }
+
+}

--- a/src/main/java/fr/inria/corese/command/utils/coreseCoreWrapper/RDFLoaderWrapper.java
+++ b/src/main/java/fr/inria/corese/command/utils/coreseCoreWrapper/RDFLoaderWrapper.java
@@ -13,14 +13,34 @@ import fr.inria.corese.core.load.LoadFormat;
  */
 public class RDFLoaderWrapper {
 
+    /**
+     * Creates a Load instance for the given graph.
+     *
+     * @param graph the graph to load data into
+     * @return a Load instance
+     */
     public static Load graphLoader(Graph graph) {
         return Load.create(graph);
     }
 
+    /**
+     * Determines the load format from the input string.
+     *
+     * @param input the input string representing the format
+     * @return the corresponding Loader.format
+     */
     public static Loader.format getLoadFormat(String input) {
         return LoadFormat.getFormat(input);
     }
 
+    /**
+     * Parses RDF data from an InputStream into the given Load instance using the specified format.
+     *
+     * @param loader      the Load instance to use for parsing
+     * @param inputStream the InputStream containing RDF data
+     * @param inputFormat the format of the RDF data
+     * @throws LoadException if an error occurs during parsing
+     */
     public static void parse(Load loader, InputStream inputStream, Load.format inputFormat) throws LoadException {
         loader.parse(inputStream, inputFormat);
     }

--- a/src/main/java/fr/inria/corese/command/utils/coreseCoreWrapper/RDFLoaderWrapper.java
+++ b/src/main/java/fr/inria/corese/command/utils/coreseCoreWrapper/RDFLoaderWrapper.java
@@ -3,8 +3,10 @@ package fr.inria.corese.command.utils.coreseCoreWrapper;
 import java.io.InputStream;
 
 import fr.inria.corese.core.Graph;
+import fr.inria.corese.core.api.Loader;
 import fr.inria.corese.core.load.Load;
 import fr.inria.corese.core.load.LoadException;
+import fr.inria.corese.core.load.LoadFormat;
 
 /** A class to gather all dependencies to Corese-core in one place
  * This one is for everything related to RDFLoading
@@ -13,6 +15,10 @@ public class RDFLoaderWrapper {
 
     public static Load graphLoader(Graph graph) {
         return Load.create(graph);
+    }
+
+    public static Loader.format getLoadFormat(String input) {
+        return LoadFormat.getFormat(input);
     }
 
     public static void parse(Load loader, InputStream inputStream, Load.format inputFormat) throws LoadException {

--- a/src/main/java/fr/inria/corese/command/utils/coreseCoreWrapper/RDFLoaderWrapper.java
+++ b/src/main/java/fr/inria/corese/command/utils/coreseCoreWrapper/RDFLoaderWrapper.java
@@ -1,8 +1,10 @@
 package fr.inria.corese.command.utils.coreseCoreWrapper;
 
+import java.io.InputStream;
 
 import fr.inria.corese.core.Graph;
 import fr.inria.corese.core.load.Load;
+import fr.inria.corese.core.load.LoadException;
 
 /** A class to gather all dependencies to Corese-core in one place
  * This one is for everything related to RDFLoading
@@ -11,6 +13,10 @@ public class RDFLoaderWrapper {
 
     public static Load graphLoader(Graph graph) {
         return Load.create(graph);
+    }
+
+    public static void parse(Load loader, InputStream inputStream, Load.format inputFormat) throws LoadException {
+        loader.parse(inputStream, inputFormat);
     }
 
 }

--- a/src/main/java/fr/inria/corese/command/utils/loader/rdf/RdfDataLoader.java
+++ b/src/main/java/fr/inria/corese/command/utils/loader/rdf/RdfDataLoader.java
@@ -12,6 +12,9 @@ import java.util.Optional;
 import fr.inria.corese.command.utils.ConvertString;
 import fr.inria.corese.command.utils.InputTypeDetector;
 import fr.inria.corese.command.utils.InputTypeDetector.InputType;
+
+import fr.inria.corese.command.utils.coreseCoreWrapper.GraphWrapper;
+import fr.inria.corese.command.utils.coreseCoreWrapper.RDFLoaderWrapper;
 import fr.inria.corese.core.Graph;
 import fr.inria.corese.core.load.Load;
 import fr.inria.corese.core.load.LoadFormat;
@@ -240,7 +243,7 @@ public class RdfDataLoader {
         }
 
         Graph graph = Graph.create();
-        Load load = Load.create(graph);
+        Load load = RDFLoaderWrapper.graphLoader(graph);
 
         try {
             load.parse(inputStream, inputFormat.getCoreseFormat());

--- a/src/main/java/fr/inria/corese/command/utils/loader/rdf/RdfDataLoader.java
+++ b/src/main/java/fr/inria/corese/command/utils/loader/rdf/RdfDataLoader.java
@@ -14,9 +14,10 @@ import fr.inria.corese.command.utils.InputTypeDetector;
 import fr.inria.corese.command.utils.InputTypeDetector.InputType;
 
 import fr.inria.corese.command.utils.coreseCoreWrapper.RDFLoaderWrapper;
-import fr.inria.corese.core.Graph;
 import fr.inria.corese.core.load.Load;
-import fr.inria.corese.core.load.LoadFormat;
+import fr.inria.corese.command.utils.coreseCoreWrapper.GraphWrapper;
+import fr.inria.corese.core.Graph;
+
 import picocli.CommandLine.Model.CommandSpec;
 
 /**
@@ -66,7 +67,7 @@ public class RdfDataLoader {
             return this.LoadFromStdin(inputFormat);
         }
 
-        Graph graph = Graph.create();
+        Graph graph = GraphWrapper.createGraph();
 
         for (String input : inputs) {
             InputType type = InputTypeDetector.detect(input);
@@ -217,7 +218,7 @@ public class RdfDataLoader {
      * @return The Corese Graph containing the RDF data.
      */
     private Graph loadFromDirectory(Path path, EnumRdfInputFormat inputFormat, boolean recursive) {
-        Graph graph = Graph.create();
+        Graph graph = GraphWrapper.createGraph();
         this.loadFromDirectoryRecursive(path, inputFormat, recursive, graph);
 
         if (this.verbose) {
@@ -241,7 +242,7 @@ public class RdfDataLoader {
                             + "Please specify the input format with the option -f.");
         }
 
-        Graph graph = Graph.create();
+        Graph graph = GraphWrapper.createGraph();
         Load load = RDFLoaderWrapper.graphLoader(graph);
 
         try {

--- a/src/main/java/fr/inria/corese/command/utils/loader/rdf/RdfDataLoader.java
+++ b/src/main/java/fr/inria/corese/command/utils/loader/rdf/RdfDataLoader.java
@@ -75,7 +75,7 @@ public class RdfDataLoader {
             switch (type) {
                 case URL:
                     Graph resultGraphUrl = this.loadFromURL(ConvertString.toUrlOrThrow(input), inputFormat);
-                    graph.merge(resultGraphUrl);
+                    GraphWrapper.mergeGraph(graph, resultGraphUrl);
                     break;
 
                 case FILE_PATH:
@@ -88,7 +88,7 @@ public class RdfDataLoader {
                     } else {
                         resultGraph = this.loadFromFile(path, inputFormat);
                     }
-                    graph.merge(resultGraph);
+                    GraphWrapper.mergeGraph(graph, resultGraph);
                     break;
 
                 default:
@@ -203,7 +203,7 @@ public class RdfDataLoader {
                     this.loadFromDirectoryRecursive(childFile.toPath(), inputFormat, recursive, graph);
                 } else if (childFile.isFile()) {
                     Graph resultGraph = this.loadFromFile(childFile.toPath(), inputFormat);
-                    graph.merge(resultGraph);
+                    GraphWrapper.mergeGraph(graph, resultGraph);
                 }
             }
         }

--- a/src/main/java/fr/inria/corese/command/utils/loader/rdf/RdfDataLoader.java
+++ b/src/main/java/fr/inria/corese/command/utils/loader/rdf/RdfDataLoader.java
@@ -233,21 +233,21 @@ public class RdfDataLoader {
      */
     private Graph loadFromInputStream(InputStream inputStream, EnumRdfInputFormat inputFormat) {
 
-        Graph graph = Graph.create();
-        Load load = Load.create(graph);
-
         if (inputFormat == null) {
             throw new IllegalArgumentException(
                     "The input format cannot be automatically determined if you use standard input or na URL. "
                             + "Please specify the input format with the option -f.");
-        } else {
-            try {
-                load.parse(inputStream, inputFormat.getCoreseFormat());
-                return graph;
-            } catch (Exception e) {
-                throw new IllegalArgumentException("Failed to parse RDF file. Check if file is well-formed and that "
-                        + "the input format is correct. " + e.getMessage(), e);
-            }
+        }
+
+        Graph graph = Graph.create();
+        Load load = Load.create(graph);
+
+        try {
+            load.parse(inputStream, inputFormat.getCoreseFormat());
+            return graph;
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to parse RDF file. Check if file is well-formed and that "
+                    + "the input format is correct. " + e.getMessage(), e);
         }
     }
 

--- a/src/main/java/fr/inria/corese/command/utils/loader/rdf/RdfDataLoader.java
+++ b/src/main/java/fr/inria/corese/command/utils/loader/rdf/RdfDataLoader.java
@@ -246,7 +246,7 @@ public class RdfDataLoader {
         Load load = RDFLoaderWrapper.graphLoader(graph);
 
         try {
-            load.parse(inputStream, inputFormat.getCoreseFormat());
+            RDFLoaderWrapper.parse( load, inputStream, inputFormat.getCoreseFormat());
             return graph;
         } catch (Exception e) {
             throw new IllegalArgumentException("Failed to parse RDF file. Check if file is well-formed and that "

--- a/src/main/java/fr/inria/corese/command/utils/loader/rdf/RdfDataLoader.java
+++ b/src/main/java/fr/inria/corese/command/utils/loader/rdf/RdfDataLoader.java
@@ -13,7 +13,6 @@ import fr.inria.corese.command.utils.ConvertString;
 import fr.inria.corese.command.utils.InputTypeDetector;
 import fr.inria.corese.command.utils.InputTypeDetector.InputType;
 
-import fr.inria.corese.command.utils.coreseCoreWrapper.GraphWrapper;
 import fr.inria.corese.command.utils.coreseCoreWrapper.RDFLoaderWrapper;
 import fr.inria.corese.core.Graph;
 import fr.inria.corese.core.load.Load;
@@ -262,7 +261,7 @@ public class RdfDataLoader {
      */
     private Optional<EnumRdfInputFormat> guessInputFormat(String input) {
 
-        EnumRdfInputFormat inputFormat = EnumRdfInputFormat.create(LoadFormat.getFormat(input));
+        EnumRdfInputFormat inputFormat = EnumRdfInputFormat.create( RDFLoaderWrapper.getLoadFormat(input));
 
         if (inputFormat == null) {
             if (this.verbose) {


### PR DESCRIPTION
Starting to create a wrapper around corese-core in corese-command.
- first a small optimization on RdfDataLoader.loadFromInputStream (test if parameter is ok before doing anything)
- created a new package fr.inria.corese.command.utils.coreseCoreWrapper
- then wrapping 3 method calls in a new class RDFLoaderWrapper
- then wrapping 2 method calls in a new class GraphWrapper
